### PR TITLE
Define User model type explicitly in layout AppShell instance

### DIFF
--- a/src/routes/(protected)/protected/+layout.svelte
+++ b/src/routes/(protected)/protected/+layout.svelte
@@ -1,6 +1,7 @@
-<script>
+<script lang="ts">
 	import AppShell from '../../../lib/components/layout/AppShell.svelte';
-	export let data;
+	import type { User } from '@prisma/client';
+	export let data: { user: User };
 </script>
 
 <AppShell user={data?.user}>


### PR DESCRIPTION
I actually couldn't reproduce this Typescript error in a fresh fork of the starter kit. Maybe Typescript only objects after we start migrating schema. It's up to you if you want to merge this or not, it could turn out to be just a superficial change.